### PR TITLE
Keystore updates & disabling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,6 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+# vim swap files
+.*.sw*

--- a/pacli/__main__.py
+++ b/pacli/__main__.py
@@ -826,7 +826,6 @@ def configured_provider(Settings):
         Provider = as_local_key_provider(Provider)
         kwargs['keystore'] = keystore = GpgKeystore(Settings, keyfile)
 
-    print(Provider, kwargs)
     provider = Provider(**kwargs)
     set_up(provider)
 

--- a/pacli/__main__.py
+++ b/pacli/__main__.py
@@ -335,7 +335,7 @@ def new_deck(provider, deck, broadcast):
     '''
     Spawn a new PeerAssets deck.
 
-    pacli deck -new '{"name": "test", "number_of_decimals": 1, "issue_mode": "ONCE"}'
+    pacli deck --new '{"name": "test", "number_of_decimals": 1, "issue_mode": "ONCE"}'
 
     Will return deck span txid.
     '''
@@ -780,7 +780,8 @@ def cli():
     parser.add_argument("--newaddress", action="store_true",
                         help="generate a new address and import to wallet")
     parser.add_argument("--status", action="store_true", help="show pacli status")
-    parser.add_argument("--addressbalance", action="store", nargs=2, help="check card balance of the address")
+    parser.add_argument("--addressbalance", action="store",
+            metavar=('DECK_ID', 'ADDRESS'), nargs=2, help="check card balance of the address")
 
     deck = subparsers.add_parser('deck', help='Deck manipulation.')
     deck.add_argument("--list", action="store_true", help="list decks")
@@ -827,7 +828,7 @@ def main():
         provider = pa.Holy(network=Settings.network)
 
     provider = KeyedProvider(provider,keysJson=mykeys)
-    set_up(provider)
+    set_up(provider.provider)
 
     args = cli()
 

--- a/pacli/config.py
+++ b/pacli/config.py
@@ -12,21 +12,24 @@ def write_default_config(conf_file=None):
         with open(conf_file, 'w') as configfile:
             config.write(configfile)
 
+optional = {
+    "keystore": "none",
+    "gnupgdir": "",
+    "gnupgagent": "", 
+    "gnupgkey": ""
+    }
+
+required = { "network", "production", "loglevel", "change"  }
+
 def read_conf(conf_file):
     config = configparser.ConfigParser()
     config.read(conf_file)
     try:
-        settings = {
-            "network": config["settings"]["network"],
-            "production": config["settings"]["production"],
-            "loglevel": config["settings"]["loglevel"],
-            "change": config["settings"]["change"],
-            "provider": config["settings"]["provider"],
-            "keystore": config["settings"]["keystore"],
-            "gnupgdir": config["settings"]["gnupgdir"],
-            "gnupgagent": config["settings"]["gnupgagent"],
-            "gnupgkey": config["settings"]["gnupgkey"]
-            }
+        settings = dict(config["settings"])
+        assert set(settings.keys()).issuperset(required)
+        for k, v in optional.items():
+            settings[k] = settings.get(k, v)
+
     except:
         print("config is outdated, saving current default config to",conf_file+".sample")
         write_default_config(conf_file+".sample")

--- a/pacli/keystore.py
+++ b/pacli/keystore.py
@@ -55,13 +55,15 @@ class KeyedProvider:
     @classmethod
     def importprivkey(self, privkey: str, label: str) -> int:
         """import <privkey> with <label>"""
-        mykey = Kutil(wif=privkey)
+        mykey = Kutil(network=self.provider.network, wif=privkey)
 
         if label not in self.privkeys.keys():
             self.privkeys[label] = []
 
-        if mykey._privkey not in [key['privkey'] for key in self.privkeys[label]]:
-            self.privkeys[label].append({"privkey":mykey._privkey,"address":mykey.address})
+        if mykey.privkey not in [key['privkey'] for key in self.privkeys[label]]:
+            self.privkeys[label].append({
+                "privkey": mykey.privkey,
+                "address": mykey.address })
 
     @classmethod
     def getaddressesbyaccount(self, label: str) -> list:

--- a/pacli/keystore.py
+++ b/pacli/keystore.py
@@ -1,52 +1,60 @@
-import gnupg
-import getpass
-import sys
+import sys, pickle
+from binascii import hexlify, unhexlify
+import gnupg, getpass
 from pypeerassets.kutil import Kutil
 
-mypg = None
+class GpgKeystore:
+    """
+    Implements reading and writing from gpg encrypted file.
+    python-gnupg is a wrapper around the gpg cli, which makes it inherently fragile
+    Uses pickle because private keys are binary
+    """
 
-def read_keystore(Settings,keyfile) -> str:
-    mykeys = ""
+    def __init__(self, Settings, keyfile):
+        assert Settings.keystore == "gnupg"
 
-    if Settings.keystore == "gnupg" and Settings.provider != "rpcnode":
-        mypg = gnupg.GPG(binary='/usr/bin/gpg',homedir=Settings.gnupgdir,use_agent=bool(Settings.gnupgagent=="True"),keyring='pubring.gpg',secring='secring.gpg')
+        self._key = Settings.gnupgkey
+        self._keyfile = keyfile
+
+        self._init_settings = dict(
+            homedir=Settings.gnupgdir,
+            use_agent=bool(Settings.gnupgagent == "True"),
+            keyring='pubring.gpg',
+            secring='secring.gpg')
+        self.gpg = gnupg.GPG(**self._init_settings)
+
+    def read(self) -> dict:
         password = getpass.getpass("Input gpg key password:")
-        fd = open(keyfile)
-        data = fd.read()
+        contents = open(self._keyfile, 'rb').read()
 
-        if len(data)>0:
-            mykeys = str(mypg.decrypt(data,passphrase=password))
-        fd.close()
-    else:
-        print("using rpcnode")
+        if not len(contents):
+            return {}
 
-    return mykeys
+        decrypted = self.gpg.decrypt(contents, passphrase=password)
 
-def write_keystore(Settings,keyfile,keys):
+        assert decrypted.ok, decrypted.status
+        return pickle.loads(unhexlify(str(decrypted).encode()))
 
-    if mypg:
-        data = str(mypg.encrypt(str(keys),Settings.gnupgkey))
-        fd = open(keyfile,"w")
-        fd.write(data)
-        fd.close()
+    def write(self, data: dict) -> str:
+        encrypted = self.gpg.encrypt(hexlify(pickle.dumps(data)).decode(), self._key)
+        assert encrypted.ok, encrypted.status
+        keyfile = open(self._keyfile, "w")
+        keyfile.write(str(encrypted))
+        keyfile.close()
+
 
 class KeyedProvider:
 
     """
-    Keystore class
+    Wraps a provider, shadowing it's private key management and deferring other logic.
+    Uses an in-memory store to handle
+        importprivkey, getaddressesbyaccount, listaccounts, and dumpprivkeys
     """
 
     @classmethod
-    def __init__(self, provider, keysJson: str=""):
-        """
-        : 
-        """
+    def __init__(self, provider, keys: dict = {}):
         self.provider = provider
-
-        if keysJson != "":
-            self.privkeys = eval(keysJson)
-        else:
-            self.privkeys = {}
+        self.privkeys = keys
 
     @classmethod
     def __getattr__(self, name):
@@ -61,8 +69,7 @@ class KeyedProvider:
             self.privkeys[label] = []
 
         if mykey.privkey not in [key['privkey'] for key in self.privkeys[label]]:
-            self.privkeys[label].append({
-                "privkey": mykey.privkey,
+            self.privkeys[label].append({ "privkey": mykey.privkey,
                 "address": mykey.address })
 
     @classmethod
@@ -77,3 +84,5 @@ class KeyedProvider:
     @classmethod
     def dumpprivkeys(self) -> dict:
         return self.privkeys
+
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-pypeerassets>=0.1.1
+pypeerassets>=0.2.1
 terminaltables>=3.1.0
-gnupg>=2.1
 appdirs


### PR DESCRIPTION
Haven't checked the whole api surface area for functionality, but figured this was a good checkpoint
#### Changes:
* keystore and corresponding config made optional
* keystore is now a dynamic subclass of the selected provider, fixing peerassets `isinstance` checks
* bundled keystore logic into `GpgKeystore`, use pickle instead of str/eval
