### PR TITLE
patch keystore class singleton behavior

### DIFF
--- a/pacli/__main__.py
+++ b/pacli/__main__.py
@@ -56,8 +56,8 @@ def set_up(provider):
         if not Settings.production:
             if not provider.listtransactions("PATEST"):
                 pa.pautils.load_p2th_privkeys_into_local_node(provider, prod=False)
-    elif Settings.provider != 'holy':
-        pa.pautils.load_p2th_privkeys_into_local_node(provider,keyfile)
+   #elif Settings.provider != 'holy':
+   #    pa.pautils.load_p2th_privkeys_into_local_node(provider, keyfile)
 
 def default_account_utxo(provider, amount):
     '''set default address to be used with pacli'''

--- a/pacli/keystore.py
+++ b/pacli/keystore.py
@@ -58,7 +58,11 @@ def as_local_key_provider(Provider):
         """
 
         def __init__(self, keystore: GpgKeystore, **kwargs):
-            super(Provider, self).__init__(**kwargs)
+            try:
+                super(Provider, self).__init__(**kwargs)
+            except TypeError:
+                self.__init__hack__ = Provider.__init__
+                self.__init__hack__(**kwargs)
             self.keystore = keystore
             self.privkeys = keystore.read()
 


### PR DESCRIPTION
this patch should handle both `RpcNode` and `Holy`